### PR TITLE
Prevent automatic close of stdin after printing exercise.

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,9 @@ var wordwrap = require('wordwrap')
 var assert = require('assertf')
 
 module.exports = function(options) {
+  // Prevent automatic close of stdin, so that input is possible after showing
+  // the problem description.
+  options.autoclose = false;
   var shop = adventure(options)
   shop.on('pass', function() {
     console.log('Type `' + options.name+ '` to show the menu.\n')

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "Tim Oxley <secoif@gmail.com>",
   "license": "ISC",
   "dependencies": {
-    "adventure": "^2.7.0",
+    "adventure": "^2.10.0",
     "assertf": "^1.0.0",
     "cpr": "^0.3.2",
     "inquirer": "^0.8.0",


### PR DESCRIPTION
This was causing an exception when inquirer tried to use stdin to
prompt about creating files, but stdin had already been closed.

Fixes https://github.com/timoxley/adventure-map/issues/4